### PR TITLE
Add GolemCore Bot to Open-source Projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ A curated list of AI agents, categorized into open-source projects and closed-so
 - [FastAgency](https://fastagency.ai/latest/) - Multi-agent AI workflow deployment tool.
 - [Flowise](https://flowiseai.com/) - Low-code AI agent builder.
 - [Friday](https://github.com/amirrezasalimi/friday/) - AI assistant for Node.js development.
+- [GolemCore Bot](https://github.com/alexk-dev/golemcore-bot) - AI agent framework for Java with skill-based architecture, MCP support, and Telegram integration.
 - [Giselle](https://github.com/giselles-ai/giselle) - AI for Agentic Workflows. Human-AI Collaboration. Open Source.
 - [GPTSwarm](https://gptswarm.org/) - Optimizable graph-based AI agents.
 - [Upsonic](https://github.com/Upsonic/Upsonic) - Reliable agent framework that support MCP.


### PR DESCRIPTION
Adding GolemCore Bot to the list of open-source projects.