### PR TITLE
Add Agent Reach — internet access scaffolding for AI agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ A curated list of AI agents, categorized into open-source projects and closed-so
 
 ## Open-source Projects
 
+- [Agent Reach](https://github.com/Panniantong/Agent-Reach) - Give your AI agents internet access in 30 seconds. Scaffolding tool supporting 9+ platforms (Twitter, YouTube, Reddit, Bilibili, Xiaohongshu, GitHub, RSS, Web, Exa search). Works with Claude Code, OpenClaw, Cursor, Windsurf. Free, open source, privacy-first.
+
 - [Adala](https://github.com/HumanSignal/Adala) - Autonomous data labeling agent framework.
 - [AgentGPT](https://agentgpt.reworkd.ai/) - Browser-based no-code AI agent tool.
 - [AutoGen](https://github.com/microsoft/autogen) - Multi-agent AI framework by Microsoft.


### PR DESCRIPTION
## Agent Reach

[Agent Reach](https://github.com/Panniantong/Agent-Reach) is a scaffolding tool that gives any AI coding agent (Claude Code, OpenClaw, Cursor, Windsurf) full internet capabilities with a single command.

**Key features:**
- 9+ platforms: Twitter/X, YouTube, Reddit, Bilibili, Xiaohongshu, GitHub, RSS, Web, Exa search
- Zero cost — all tools open source, all APIs free
- Privacy-first — cookies stay local, fully auditable
- Built-in diagnostics via `agent-reach doctor`

GitHub: https://github.com/Panniantong/Agent-Reach
