### PR TITLE
Add KinBot - self-hosted AI agent platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ A curated list of AI agents, categorized into open-source projects and closed-so
 - [Friday](https://github.com/amirrezasalimi/friday/) - AI assistant for Node.js development.
 - [Giselle](https://github.com/giselles-ai/giselle) - AI for Agentic Workflows. Human-AI Collaboration. Open Source.
 - [GPTSwarm](https://gptswarm.org/) - Optimizable graph-based AI agents.
+- [KinBot](https://github.com/MarlBurroW/kinbot) - Self-hosted AI agent platform with persistent memory, 23+ LLM providers, and 6 messaging channels (Telegram, Discord, Slack, WhatsApp, Signal, Matrix).
 - [Upsonic](https://github.com/Upsonic/Upsonic) - Reliable agent framework that support MCP.
 
 ---


### PR DESCRIPTION
**[KinBot](https://github.com/MarlBurroW/kinbot)** is a self-hosted AI agent platform built with Bun, Hono, React, and SQLite.

Key features:
- **Persistent memory** with hybrid search and LLM re-ranking
- **23+ LLM providers** including Ollama for fully local setups
- **6 messaging channels**: Telegram, Discord, Slack, WhatsApp, Signal, Matrix
- **Mini-Apps**: agents can generate interactive web applications
- **Plugin system** with hot-reload
- **Cron jobs** for autonomous agent tasks
- Lightweight enough to run on a Raspberry Pi

MIT licensed. Active development (v0.22.1).