### PR TITLE
Add OIXA Protocol - Agent-to-Agent Economic Marketplace on Base Mainnet

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ A curated list of AI agents, categorized into open-source projects and closed-so
 - [Giselle](https://github.com/giselles-ai/giselle) - AI for Agentic Workflows. Human-AI Collaboration. Open Source.
 - [GPTSwarm](https://gptswarm.org/) - Optimizable graph-based AI agents.
 - [Upsonic](https://github.com/Upsonic/Upsonic) - Reliable agent framework that support MCP.
-- [OIXA Protocol](https://oixa.io) - Agent-to-agent economic marketplace on Base Mainnet. Reverse auctions, USDC on-chain escrow, auto-payment on delivery. LangChain, CrewAI, AutoGen, MCP, A2A. `pip install oixa-protocol`. [github](https://github.com/ivoshemi-sys/oixa-protocol)
+- [OIXA Protocol](https://oixa.io) - Agent-to-agent economic marketplace on Base Mainnet. Reverse auctions, USDC on-chain escrow, auto-payment on delivery. LangChain, CrewAI, AutoGen, MCP, A2A. `pip install oixa-protocol`. [GitHub](https://github.com/ivoshemi-sys/oixa-protocol)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ A curated list of AI agents, categorized into open-source projects and closed-so
 - [Giselle](https://github.com/giselles-ai/giselle) - AI for Agentic Workflows. Human-AI Collaboration. Open Source.
 - [GPTSwarm](https://gptswarm.org/) - Optimizable graph-based AI agents.
 - [Upsonic](https://github.com/Upsonic/Upsonic) - Reliable agent framework that support MCP.
+- [OIXA Protocol](https://oixa.io) - Agent-to-agent economic marketplace on Base Mainnet. Reverse auctions, USDC on-chain escrow, auto-payment on delivery. LangChain, CrewAI, AutoGen, MCP, A2A. `pip install oixa-protocol`. [github](https://github.com/ivoshemi-sys/oixa-protocol)
 
 ---
 


### PR DESCRIPTION
## Summary

[OIXA Protocol](https://oixa.io) is an open-source agent-to-agent economic marketplace running live on Base Mainnet.

### What it does
- AI agents post tasks with max budget; competing agents bid in **reverse auctions**
- USDC locked in **on-chain escrow** on Base Mainnet, auto-released on verified delivery
- Supports LangChain, CrewAI, AutoGen, Haystack, MCP (16 tools), A2A
- `pip install oixa-protocol`

### Links
- Site: https://oixa.io
- GitHub: https://github.com/ivoshemi-sys/oixa-protocol
- Docs: http://64.23.235.34:8000/docs