### PR TITLE
Add Overloop CLI and Signals CLI

### DIFF
--- a/data/overloop-cli.yml
+++ b/data/overloop-cli.yml
@@ -1,0 +1,10 @@
+name: Overloop CLI
+slug: overloop-cli
+url: https://github.com/sortlist/overloop-cli
+position: ordinary
+oneliner: AI-powered outbound engine. Source 450M+ contacts, email + LinkedIn campaigns, conversations. JSON output.
+description: AI-powered outbound engine. Source 450M+ contacts, email + LinkedIn campaigns, conversations. JSON output.
+main_category: closed-source
+categories: []
+date_added: 2026-03-31
+date_modified: 2026-03-31

--- a/data/signals-cli.yml
+++ b/data/signals-cli.yml
@@ -1,0 +1,10 @@
+name: Signals CLI
+slug: signals-cli
+url: https://github.com/sortlist/signals-cli
+position: ordinary
+oneliner: Intent signal monitoring. LinkedIn engagers, keyword posters, job changers, funding. JSON output.
+description: Intent signal monitoring. LinkedIn engagers, keyword posters, job changers, funding. JSON output.
+main_category: closed-source
+categories: []
+date_added: 2026-03-31
+date_modified: 2026-03-31


### PR DESCRIPTION
## Summary
- Add **Overloop CLI** (`npm i -g overloop-cli`) -- AI-powered outbound engine. Source 450M+ contacts, run email + LinkedIn campaigns, manage conversations. JSON output. https://github.com/sortlist/overloop-cli
- Add **Signals CLI** (`npm i -g signals-sortlist-cli`) -- Intent signal monitoring. Track LinkedIn engagers, keyword posters, job changers, funding events. JSON output. https://github.com/sortlist/signals-cli

Both added as closed-source entries following the YAML data format in `data/`.