### PR TITLE
Add Dakera — persistent memory layer for AI agents

### DIFF
--- a/data/dakera.yml
+++ b/data/dakera.yml
@@ -1,6 +1,6 @@
 name: Dakera
 slug: dakera
-url: https://github.com/Dakera-AI/dakera
+url: https://github.com/dakera-ai/dakera-deploy
 oneliner: Persistent memory layer for AI agents with hybrid BM25 + vector retrieval.
 description: Dakera is a production-ready persistent memory layer for AI agents, providing hybrid BM25 + vector retrieval, temporal reasoning, importance-weighted decay, and multi-tenant namespacing. Integrates with LangChain, LlamaIndex, CrewAI, and AutoGen.
 main_category: open-source

--- a/data/dakera.yml
+++ b/data/dakera.yml
@@ -1,0 +1,9 @@
+name: Dakera
+slug: dakera
+url: https://github.com/Dakera-AI/dakera
+oneliner: Persistent memory layer for AI agents with hybrid BM25 + vector retrieval.
+description: Dakera is a production-ready persistent memory layer for AI agents, providing hybrid BM25 + vector retrieval, temporal reasoning, importance-weighted decay, and multi-tenant namespacing. Integrates with LangChain, LlamaIndex, CrewAI, and AutoGen.
+main_category: open-source
+categories: []
+date_added: 2026-05-13
+date_modified: 2026-05-13


### PR DESCRIPTION
Adds Dakera to the open-source agents list.

**Dakera** is a production-ready persistent memory layer for AI agents. It provides hybrid BM25 + vector retrieval, temporal reasoning, and importance-weighted memory decay — enabling agents to remember across sessions with semantically-ranked recall.

- GitHub: https://github.com/Dakera-AI/dakera
- Docs: https://docs.dakera.ai
- PyPI integrations: `langchain-dakera`, `llamaindex-dakera`, `crewai-dakera`, `autogen-dakera`