### PR TITLE
Add: Alfred

### DIFF
--- a/data/alfred.yml
+++ b/data/alfred.yml
@@ -1,0 +1,10 @@
+name: Alfred
+slug: alfred
+url: https://github.com/luminik-io/alfred-os
+position: ordinary
+oneliner: Self-hosted runtime for autonomous Claude Code and Codex agents.
+description: Alfred is a self-hosted Python runtime that turns scoped GitHub issues into reviewed pull requests through autonomous Claude Code and Codex agents on a developer's own subscription, with per-firing git worktrees, label-driven state, role-based engine routing, and Slack reporting.
+main_category: open-source
+categories: []
+date_added: 2026-05-23
+date_modified: 2026-05-23


### PR DESCRIPTION
Adds Alfred via `data/alfred.yml`. README is left untouched per CONTRIBUTING (CI regenerates it).

### What is Alfred
A self-hosted Python runtime that turns scoped GitHub issues into reviewed pull requests through autonomous Claude Code and Codex agents running on a developer's own CLI subscription. Per-firing git worktrees, label-driven state machine, role-based engine routing, and Slack reporting. MIT, macOS/Linux.

### CONTRIBUTING compliance
- One YAML file at `data/alfred.yml`; filename matches slug.
- Required fields present: name, slug, url, oneliner, main_category (`open-source`).
- README is untouched.
- Alphabetical placement preserved (file goes in `data/` between `aider.yml` and `ailice.yml`).

### Sources
- https://github.com/luminik-io/alfred-os
- https://alfred.luminik.io/