### PR TITLE
add NERV to open-source projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ A curated list of AI agents, categorized into open-source projects and closed-so
 - [Friday](https://github.com/amirrezasalimi/friday/) - AI assistant for Node.js development.
 - [Giselle](https://github.com/giselles-ai/giselle) - AI for Agentic Workflows. Human-AI Collaboration. Open Source.
 - [GPTSwarm](https://gptswarm.org/) - Optimizable graph-based AI agents.
+- [NERV](https://github.com/juanmanueldaza/nerv) - Minimalist agent harness with Spec-Driven Development (SDD), A2A protocol, ChromaDB memory, and CLI scaffolding.
 - [Upsonic](https://github.com/Upsonic/Upsonic) - Reliable agent framework that support MCP.
 
 ---


### PR DESCRIPTION
Add [NERV](https://github.com/juanmanueldaza/nerv) — minimal agent harness with Spec-Driven Development (SDD), A2A protocol support, ChromaDB persistent memory, and CLI scaffolding. 40 files, 14 skills, 5 MCP servers, GPL-2.0. Built for steerability, not orchestration.