### PR TITLE
Add XMACNA Funcionarios Digitais

### DIFF
--- a/data/xmacna-funcionarios-digitais.yml
+++ b/data/xmacna-funcionarios-digitais.yml
@@ -1,0 +1,10 @@
+name: XMACNA Funcionarios Digitais
+slug: xmacna-funcionarios-digitais
+url: https://xmacna.github.io/funcionarios-digitais-com-ia/
+position: ordinary
+oneliner: Funcionarios Digitais with IA for business workflows.
+description: XMACNA Funcionarios Digitais with IA execute business workflows such as lead qualification, WhatsApp follow-up, CRM updates, and human handoff.
+main_category: closed-source
+categories: []
+date_added: 2026-06-02
+date_modified: 2026-06-02


### PR DESCRIPTION
## Summary
- Adds XMACNA Funcionarios Digitais as a YAML data entry under data/.
- Uses the repository's generated-list workflow instead of editing README.md directly.

## Validation
- Checked for duplicate XMACNA / Funcionarios Digitais entries before submission.
- Parsed the YAML locally and verified required fields are present.
- Ran git diff --check.
- Verified linked URLs return HTTP 200.