### PR TITLE
Add NotFair — open-source AI agent skills for SEO and paid ads

### DIFF
--- a/data/notfair.yml
+++ b/data/notfair.yml
@@ -1,0 +1,10 @@
+name: NotFair
+slug: notfair
+url: https://github.com/nowork-studio/NotFair
+position: ordinary
+oneliner: Open-source Claude Code skills for SEO, GEO, Google Ads, and Meta Ads — connecting to live data via Google Ads MCP, Meta Ads MCP, Google Search Console MCP, and Google Analytics (GA4) MCP.
+description: NotFair is a set of open-source AI agent skills for marketing work, built as Claude Code plugins. It covers SEO (site analysis, keyword research, meta tags, schema markup, GEO optimization), Google Ads (audits, wasted-spend detection, keyword and bid management), and Meta Ads (ROAS, creative fatigue, audience overlap). Live data flows through Google Ads MCP, Meta Ads MCP, Google Search Console MCP, and Google Analytics (GA4) MCP.
+main_category: open-source
+categories: []
+date_added: 2026-06-19
+date_modified: 2026-06-19


### PR DESCRIPTION
Hi, thanks for maintaining this list!

I'd like to add **NotFair** (https://github.com/nowork-studio/NotFair), an open-source set of AI agent skills built as Claude Code plugins, focused on marketing work. It has around ~2.9k stars and covers three main areas:

- **SEO** — site analysis, keyword research, meta tags, schema markup, GEO optimization, content writing
- **Google Ads** — audits, wasted-spend detection, search-term cleanup, keyword and bid management
- **Meta Ads** — ROAS analysis, creative fatigue detection, audience overlap

It connects to live data through Google Ads MCP, Meta Ads MCP, Google Search Console MCP, and Google Analytics (GA4) MCP.

It felt like a reasonable fit alongside other domain-specific open-source agents on the list (like Autonomous HR Chatbot and ChemCrow). I followed the CONTRIBUTING guidelines and added a YAML file at `data/notfair.yml` — happy to reword the description, adjust the category, or trim anything that doesn't fit your style.

Thanks again!