### PR TITLE
Add ax data entry

### DIFF
--- a/data/ax.yml
+++ b/data/ax.yml
@@ -1,0 +1,10 @@
+name: ax
+slug: ax
+url: https://github.com/Necmttn/ax
+position: ordinary
+oneliner: Local-first evidence graph for AI coding-agent sessions.
+description: Indexes local coding-agent transcripts and exposes read-only MCP queries for sessions, tool calls, skills, and cost.
+main_category: open-source
+categories: []
+date_added: 2026-06-20
+date_modified: 2026-06-20


### PR DESCRIPTION
Summary:
- Add ax as an open-source AI agent tooling entry in the YAML source data.
- Keep README untouched because this list is generated by opendata.

Validation:
- git diff --check HEAD~1..HEAD
- Parsed data/ax.yml with Ruby YAML
- Confirmed the Necmttn/ax URL appears once in source data
- Checked the ax GitHub link returns successfully
- Confirmed README.md has no direct diff

Note: I could not run the Go-backed opendata compiler locally because this environment does not have go installed.

---

_Generated with [ax](https://github.com/Necmttn/ax)._