### PR TITLE
Add LoopTroop to open-source projects

### DIFF
--- a/data/looptroop.yml
+++ b/data/looptroop.yml
@@ -1,0 +1,10 @@
+name: LoopTroop
+slug: looptroop
+url: https://github.com/looptroop-ai/LoopTroop
+position: ordinary
+oneliner: Local GUI orchestrator for AI coding agents with LLM Council planning, isolated git worktrees, and Ralph Loop recovery.
+description: Local GUI orchestrator for AI coding agents with LLM Council planning, isolated git worktrees, and Ralph Loop recovery.
+main_category: open-source
+categories: []
+date_added: 2026-06-21
+date_modified: 2026-06-21


### PR DESCRIPTION
## What

Adding [LoopTroop](https://github.com/looptroop-ai/LoopTroop) as a new open-source entry.

## How

Per CONTRIBUTING, I added `data/looptroop.yml` (did not edit README.md directly). CI should pick it up and regenerate the README under **Open-source Projects**, alphabetically between LocalGPT and LoopGPT-ish entries.

## Why it fits

LoopTroop is a local, open-source GUI orchestrator that takes a coding ticket all the way to a merged PR. An LLM Council drafts and votes on the plan, work is split into atomic "beads" that run in isolated git worktrees, and a "Ralph Loop" retries failed beads with a fresh context window instead of continuing a polluted chat. Built on OpenCode, MIT licensed.

## Checklist

- [x] Entry added in `data/` as a YAML file (slug matches filename)
- [x] `main_category: open-source`
- [x] Required fields present: name, slug, url, oneliner, main_category
- [x] Alphabetical order will be maintained by the generator
- [x] Did not edit README.md directly
