### PR TITLE
Add Xquik to open-source agents

### DIFF
--- a/data/aider.yml
+++ b/data/aider.yml
@@ -1,10 +1,10 @@
 name: Aider
 slug: aider
-url: https://github.com/paul-gauthier/aider
+url: https://github.com/Aider-AI/aider
 position: ordinary
 oneliner: Command-line AI coding assistant.
 description: Command-line AI coding assistant.
 main_category: open-source
 categories: []
 date_added: 2026-02-01
-date_modified: 2026-02-01
+date_modified: 2026-07-18

--- a/data/beebot.yml
+++ b/data/beebot.yml
@@ -1,10 +1,10 @@
 name: BeeBot
 slug: beebot
-url: https://github.com/AutoPackAI/beebot
+url: https://github.com/erik-megarad/beebot
 position: ordinary
 oneliner: Early-stage AI agent research project.
 description: Early-stage AI agent research project.
 main_category: open-source
 categories: []
 date_added: 2026-02-01
-date_modified: 2026-02-01
+date_modified: 2026-07-18

--- a/data/clippy.yml
+++ b/data/clippy.yml
@@ -1,10 +1,10 @@
 name: Clippy
 slug: clippy
-url: https://github.com/ennucore/clippy/
+url: https://github.com/ennucore/clippinator
 position: ordinary
 oneliner: Autonomous AI coding agent.
 description: Autonomous AI coding agent.
 main_category: open-source
 categories: []
 date_added: 2026-02-01
-date_modified: 2026-02-01
+date_modified: 2026-07-18

--- a/data/crewai.yml
+++ b/data/crewai.yml
@@ -1,10 +1,10 @@
 name: CrewAI
 slug: crewai
-url: https://github.com/joaomdmoura/crewai
+url: https://github.com/crewAIInc/crewAI
 position: featured
 oneliner: Framework for multi-agent orchestration.
 description: Framework for multi-agent orchestration.
 main_category: open-source
 categories: []
 date_added: 2026-02-01
-date_modified: 2026-02-01
+date_modified: 2026-07-18

--- a/data/dotagent.yml
+++ b/data/dotagent.yml
@@ -1,10 +1,10 @@
 name: dotagent
 slug: dotagent
-url: https://github.com/dot-agent/dotagent
+url: https://github.com/dot-agent/nextpy
 position: ordinary
 oneliner: Deployable AI agents for cloud, PC, and mobile.
 description: Deployable AI agents for cloud, PC, and mobile.
 main_category: open-source
 categories: []
 date_added: 2026-02-01
-date_modified: 2026-02-01
+date_modified: 2026-07-18

--- a/data/xquik.yml
+++ b/data/xquik.yml
@@ -1,0 +1,10 @@
+name: Xquik
+slug: xquik
+url: https://github.com/Xquik-dev/x-twitter-scraper
+position: ordinary
+oneliner: Agent Skill for public X data workflows through REST API and MCP.
+description: Agent Skill for X search, monitoring, extraction, webhooks, and confirmation-gated publishing through REST API and MCP. Xquik is an independent third-party service. Not affiliated with X Corp. "Twitter" and "X" are trademarks of X Corp.
+main_category: open-source
+categories: []
+date_added: 2026-06-23
+date_modified: 2026-07-19


### PR DESCRIPTION
## Summary

- Add Xquik as an open-source Agent Skill resource in the YAML source.
- Describe focused public X data workflows through REST API and MCP.
- Leave README generation to the repository OpenData workflow.

## Independent repository fixes

- Replace 5 retired repository identities with the canonical GitHub repositories that those records now resolve to.
- Repair Aider, BeeBot, Clippy, CrewAI, and dotagent links without changing their catalog identities.

## Validation

- Parsed all 44 YAML records with Ruby YAML
- Verified required fields, filename-to-slug identity, unique slugs, and valid main categories
- Built the pinned `alternbits/opendata@0.1.4` compiler and compiled the catalog successfully
- Verified generated README rows for Xquik and all 5 repaired links
- Verified each retired GitHub identity resolves to the recorded canonical repository
- Xquik repository, docs, MCP overview, and manifest return HTTP 200
- Added-line punctuation scan
- `git diff --check`

The GitHub Actions workflow requires maintainer approval before it can start for this fork.

Xquik is an independent third-party service. Not affiliated with X Corp. "Twitter" and "X" are trademarks of X Corp.