### PR TITLE
Add rust-norion

### DIFF
--- a/data/rust-norion.yml
+++ b/data/rust-norion.yml
@@ -1,0 +1,10 @@
+name: rust-norion
+slug: rust-norion
+url: https://github.com/yanghao1143/rust-norion
+position: ordinary
+oneliner: Rust prototype for AI runtime-control boundaries.
+description: Rust prototype for AI runtime-control boundaries with routing, memory gates, evidence checks, rollback, and audit traces.
+main_category: open-source
+categories: []
+date_added: 2026-06-25
+date_modified: 2026-06-25


### PR DESCRIPTION
Adds rust-norion as an open-source AI agent infrastructure/control-layer project.

Why this fits:
- the repository tracks open-source AI agent projects;
- rust-norion is a Rust prototype for runtime-control boundaries around inference and agent workflows;
- the entry is added through the generated data source instead of editing README.md directly.

Scope note: rust-norion is an early research-engineering prototype, not a production inference engine.