### PR TITLE
Add AgentLine — open-source telephony API for AI agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ A curated list of AI agents, categorized into open-source projects and closed-so
 - [CrewAI](https://github.com/joaomdmoura/crewai) - Framework for multi-agent orchestration.
 - [Agent4Rec](https://github.com/LehengTHU/Agent4Rec) - A recommender system simulator using 1,000 generative agents.
 - [AgentForge](https://github.com/DataBassGit/AgentForge) - LLM-agnostic platform for building and testing AI agents.
+- [AgentLine](https://github.com/AgentLineHQ/AgentLine) - Open-source telephony API for AI agents — voice calls, SMS, and phone numbers via MCP or webhooks.
 - [AgentPilot](https://github.com/jbexta/AgentPilot) - Desktop app for building, managing, and chatting with AI agents.
 - [Agents](https://github.com/aiwaves-cn/agents) - Library/framework for building language agents.
 - [AgentVerse](https://github.com/OpenBMB/AgentVerse) - Platform for task-solving and simulation AI agents.


### PR DESCRIPTION
Add [AgentLine](https://github.com/AgentLineHQ/AgentLine) — an open-source telephony API that gives AI agents real phone numbers for voice calls and SMS. Works with OpenClaw, Hermes Agent, Claude Code, and any LLM via MCP or webhooks.