### PR TITLE
Add Tree Ring Memory

### DIFF
--- a/data/tree-ring-memory.yml
+++ b/data/tree-ring-memory.yml
@@ -1,0 +1,10 @@
+name: Tree Ring Memory
+slug: tree-ring-memory
+url: https://github.com/TerminallyLazy/Tree-Ring-Memory
+position: ordinary
+oneliner: Local-first memory lifecycle framework for AI agents.
+description: Local-first, Rust-native memory lifecycle framework for AI agents with SQLite/FTS recall, audit, consolidation, forgetting, and portable skill adapters.
+main_category: open-source
+categories: []
+date_added: 2026-07-08
+date_modified: 2026-07-08


### PR DESCRIPTION
Adds Tree Ring Memory as an open-source AI-agent memory lifecycle framework.

Tree Ring Memory is a local-first, Rust-native framework for AI agents with SQLite/FTS recall, audit, consolidation, forgetting, and portable skill adapters.

Validation performed:
- Added a single structured YAML entry under `data/` per `CONTRIBUTING.md`
- Parsed `data/tree-ring-memory.yml` with Ruby YAML
- Ran `git diff --check`