### PR TITLE
Add LLMGraph

### DIFF
--- a/data/llmgraph.yml
+++ b/data/llmgraph.yml
@@ -1,0 +1,10 @@
+name: LLMGraph
+slug: llmgraph
+url: https://llmgraph.ai
+position: ordinary
+oneliner: No-code visual builder for LLM workflows and AI agents.
+description: No-code visual builder for LLM workflows and AI agents; deploys each workflow as a REST API and embeddable chat widget.
+main_category: closed-source
+categories: []
+date_added: 2026-07-10
+date_modified: 2026-07-10


### PR DESCRIPTION
Adds LLMGraph under Closed-source Projects & Companies via `data/llmgraph.yml` (README is CI-compiled per CONTRIBUTING.md).

LLMGraph is a no-code visual builder for LLM workflows and AI agents; each workflow deploys as a REST API and embeddable chat widget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)